### PR TITLE
Update the Dock API to automatically retrieve the hardware revision

### DIFF
--- a/pyshimmer/__init__.py
+++ b/pyshimmer/__init__.py
@@ -19,7 +19,7 @@ from .bluetooth.bt_commands import DataPacket
 from .dev.base import DEFAULT_BAUDRATE
 from .dev.channels import ChannelDataType, EChannelType, ESensorGroup
 from .dev.exg import ExGMux, ExGRLDLead, ERLDRef, ExGRegister
-from .dev.fw_version import FirmwareType
+from .dev.fw_version import FirmwareType, FirmwareVersion
 from .dev.revisions import (
     HardwareRevision,
     Shimmer3Revision,

--- a/pyshimmer/uart/dock_api.py
+++ b/pyshimmer/uart/dock_api.py
@@ -19,25 +19,46 @@ import struct
 
 from serial import Serial
 
-from pyshimmer.dev.revisions import RevisionRegistry
 from pyshimmer.dev.exg import ExGRegister
-from pyshimmer.dev.fw_version import FirmwareType
+from pyshimmer.dev.fw_version import FirmwareType, FirmwareVersion
+from pyshimmer.dev.revisions import RevisionRegistry, HardwareRevision, HardwareVersion
 from pyshimmer.uart.dock_const import *
 from pyshimmer.uart.dock_serial import DockSerial
 from pyshimmer.util import unpack
 
 
 class ShimmerDock:
-    """Main API to communicate with the Shimmer over the Dock UART
 
-    :arg ser: The serial interface to use for communication
+    def __init__(
+        self,
+        ser: Serial,
+        flush_before_req: bool = True,
+        revision: HardwareRevision = None,
+    ):
+        """Main API to communicate with the Shimmer over the Dock UART
 
-    """
-
-    def __init__(self, ser: Serial, flush_before_req=True):
-        self._revision = RevisionRegistry.REV_SHIMMER3
+        :param ser: The serial interface that connects to the Shimmer hardware
+            dock
+        :param flush_before_req: If set to True, the input buffer is flushed
+            before a new command is sent to the Shimmer. There should normally
+            be no harm in turning this option on. It is on by default.
+        :param revision: Manually specify the hardware revision of the Shimmer
+            that is placed in the dock. If set to None, the class will try to
+            automatically determine the revision upon connecting to the Shimmer
+            in the dock.
+        """
         self._serial = DockSerial(ser)
         self._flush_before_req = flush_before_req
+
+        if revision is None:
+            hw_version, _, _ = self.get_hw_sw_version()
+            self._revision = RevisionRegistry.get_revision(hw_version)
+        else:
+            self._revision = revision
+
+    @property
+    def revision(self) -> HardwareRevision:
+        return self._revision
 
     def __enter__(self):
         return self
@@ -182,29 +203,31 @@ class ShimmerDock:
         )
         return self._revision.ticks2sec(ticks)
 
-    def get_firmware_version(self) -> tuple[int, FirmwareType, int, int, int]:
+    def get_hw_sw_version(
+        self,
+    ) -> tuple[HardwareVersion, FirmwareType, FirmwareVersion]:
         """Retrieve the firmware version of the device
 
         :return: A tuple containing the following values:
             - The hardware version, should be 3 for Shimmer3
             - The firmware type: LogAndStream or SDLog
-            - The major release version
-            - The minor release version
-            - The patch level
+            - The firmware version
         """
         self._write_packet(UART_GET, UART_COMP_SHIMMER, UART_PROP_VER)
-        hw_ver, fw_type_bin, major, minor, rel = self._read_response_wformat_verify(
+        hw_ver_int, fw_type_bin, major, minor, rel = self._read_response_wformat_verify(
             UART_COMP_SHIMMER, UART_PROP_VER, "<BHHBB"
         )
+        hw_ver = HardwareVersion.from_int(hw_ver_int)
         fw_type = FirmwareType.from_int(fw_type_bin)
-        return hw_ver, fw_type, major, minor, rel
+        fw_version = FirmwareVersion(major, minor, rel)
+        return hw_ver, fw_type, fw_version
 
     def get_firmware_type(self) -> FirmwareType:
         """Retrieve the active firmware type
 
         :return: The firmware type: LogAndStream or SDLog
         """
-        _, fw_type, _, _, _ = self.get_firmware_version()
+        _, fw_type, _ = self.get_hw_sw_version()
         return fw_type
 
     def get_infomem(self, addr: int, dlen: int) -> bytes:

--- a/test/uart/test_dock_api.py
+++ b/test/uart/test_dock_api.py
@@ -2,17 +2,27 @@ from __future__ import annotations
 
 import pytest
 
-from pyshimmer import FirmwareType, ShimmerDock
+from pyshimmer import (
+    FirmwareType,
+    ShimmerDock,
+    RevisionRegistry,
+    HardwareVersion,
+    FirmwareVersion,
+)
 from pyshimmer.test_util import MockSerial
 
 
 class TestDockAPI:
 
-    @pytest.fixture()
-    def sot_and_mock(self) -> tuple[ShimmerDock, MockSerial]:
+    @pytest.fixture(
+        scope="function",
+        params=[RevisionRegistry.REV_SHIMMER3, RevisionRegistry.REV_SHIMMER3R],
+    )
+    def sot_and_mock(self, request) -> tuple[ShimmerDock, MockSerial]:
         mock = MockSerial()
+
         # noinspection PyTypeChecker
-        dock = ShimmerDock(mock, flush_before_req=False)
+        dock = ShimmerDock(mock, flush_before_req=False, revision=request.param)
 
         return dock, mock
 
@@ -33,40 +43,52 @@ class TestDockAPI:
 
         assert mock.test_closed
 
+    def test_hw_ver_detection(self):
+        mock = MockSerial()
+
+        # Put the response data for a Shimmer3 hardware revision
+        mock.test_put_read_data(
+            b"\x24\x02\x09\x01\x03\x03\x03\x00\x00\x00\x0b\x00\x14\x33"
+        )
+
+        dock = ShimmerDock(mock, flush_before_req=False, revision=None)
+
+        assert dock.revision is RevisionRegistry.REV_SHIMMER3
+
     def test_unknown_start_char(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x25")
         with pytest.raises(IOError):
-            sot.get_firmware_version()
+            sot.get_hw_sw_version()
 
     def test_bad_arg_response(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x24\xfd")
         with pytest.raises(IOError):
-            sot.get_firmware_version()
+            sot.get_hw_sw_version()
 
     def test_bad_cmd_response(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x24\xfc")
         with pytest.raises(IOError):
-            sot.get_firmware_version()
+            sot.get_hw_sw_version()
 
     def test_bad_crc_response(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x24\xfe")
         with pytest.raises(IOError):
-            sot.get_firmware_version()
+            sot.get_hw_sw_version()
 
     def test_unexpected_cmd_response(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x24\x03")
         with pytest.raises(IOError):
-            sot.get_firmware_version()
+            sot.get_hw_sw_version()
 
     def test_unexpected_component(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x24\x02\x02\x02\x00\x98z")
         with pytest.raises(IOError):
-            sot.get_firmware_version()
+            sot.get_hw_sw_version()
 
     def test_unexpected_property(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x24\x02\x02\x01\x02\xaaE")
         with pytest.raises(IOError):
-            sot.get_firmware_version()
+            sot.get_hw_sw_version()
 
     def test_get_mac_address(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x24\x02\x08\x01\x02\x01\x02\x03\x04\x05\x06N\x87")
@@ -79,15 +101,13 @@ class TestDockAPI:
         mock.test_put_read_data(
             b"\x24\x02\x09\x01\x03\x03\x03\x00\x00\x00\x0b\x00\x14\x33"
         )
-        hw_ver, fw_type, major, minor, patch = sot.get_firmware_version()
+        hw_ver, fw_type, fw_ver = sot.get_hw_sw_version()
 
         assert mock.test_get_write_data() == b"\x24\x03\x02\x01\x03\xca\xdc"
 
-        assert hw_ver == 3
+        assert hw_ver is HardwareVersion.SHIMMER3
         assert fw_type == FirmwareType.LogAndStream
-        assert major == 0
-        assert minor == 11
-        assert patch == 0
+        assert fw_ver == FirmwareVersion(0, 11, 0)
 
     def test_set_rtc(self, sot: ShimmerDock, mock: MockSerial):
         mock.test_put_read_data(b"\x24\xff\xd9\xb2")


### PR DESCRIPTION
The change includes the following modifications:
* Rename get_firmware_version to get_hw_sw_version
* Augment the return types with newly introduced enums and classes
* Automatically call get_hw_sw_version on instantiation to determine the hardware revision