### PR TITLE
Harmonize context managers and close methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -264,21 +264,19 @@ calls.
 
 
     if __name__ == '__main__':
-        serial = Serial('/dev/rfcomm42', DEFAULT_BAUDRATE)
-        shim_dev = ShimmerBluetooth(serial)
+        with (
+                Serial('/dev/rfcomm42', DEFAULT_BAUDRATE) as serial,
+                ShimmerBluetooth(serial) as shim_dev
+             ):
 
-        shim_dev.initialize()
+            dev_name = shim_dev.get_device_name()
+            print(f'My name is: {dev_name}')
 
-        dev_name = shim_dev.get_device_name()
-        print(f'My name is: {dev_name}')
+            shim_dev.add_stream_callback(handler)
 
-        shim_dev.add_stream_callback(handler)
-
-        shim_dev.start_streaming()
-        time.sleep(5.0)
-        shim_dev.stop_streaming()
-
-        shim_dev.shutdown()
+            shim_dev.start_streaming()
+            time.sleep(5.0)
+            shim_dev.stop_streaming()
 
 The example shows how to make simple calls and how to use the Bluetooth streaming capabilities of the device.
 
@@ -292,13 +290,11 @@ Using the Dock API
     from pyshimmer import ShimmerDock, DEFAULT_BAUDRATE, fmt_hex
 
     if __name__ == '__main__':
-        serial = Serial('/dev/ttyPPGdev', DEFAULT_BAUDRATE)
-        shim_dock = ShimmerDock(serial)
+        with Serial('/dev/ttyPPGdev', DEFAULT_BAUDRATE) as serial:
+            shim_dock = ShimmerDock(serial)
 
-        mac = shim_dock.get_mac_address()
-        print(f'Device MAC: {fmt_hex(mac)}')
-
-        shim_dock.close()
+            mac = shim_dock.get_mac_address()
+            print(f'Device MAC: {fmt_hex(mac)}')
 
 Using the Dock API works very similar to the Bluetooth API. However, it does not require a separate initialization call
 because it does not use a background thread to decode incoming messages.

--- a/pyshimmer/bluetooth/bt_api.py
+++ b/pyshimmer/bluetooth/bt_api.py
@@ -496,7 +496,6 @@ class ShimmerBluetooth:
         """
         self._serial.cancel_read()
         self._thread.join()
-        self._serial.close()
         self._bluetooth.clear_queues()
 
     def _run_readloop(self):

--- a/pyshimmer/serial_base.py
+++ b/pyshimmer/serial_base.py
@@ -112,6 +112,10 @@ class SerialBase:
         self._serial = serial
         self._reader = BufferedReader(serial)
 
+    @property
+    def raw_serial(self) -> Serial:
+        return self._serial
+
     @staticmethod
     def _retrieve_packed(fn_read: Callable[[int], bytes], rformat: str) -> any:
         read_len = struct.calcsize(rformat)
@@ -209,7 +213,3 @@ class SerialBase:
             the format string
         """
         return self._retrieve_packed(self.peek, rformat)
-
-    def close(self) -> None:
-        """Close the underlying serial stream"""
-        self._serial.close()

--- a/pyshimmer/uart/dock_api.py
+++ b/pyshimmer/uart/dock_api.py
@@ -60,12 +60,6 @@ class ShimmerDock:
     def revision(self) -> HardwareRevision:
         return self._revision
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.close()
-
     def _read_resp_type_or_throw(self, expected: int) -> int:
         r = self._serial.read_byte()
         if r != START_CHAR:
@@ -141,10 +135,6 @@ class ShimmerDock:
         self._serial.start_read_crc_verify()
         self._read_resp_type_or_throw(UART_ACK_RESPONSE)
         self._serial.end_read_crc_verify()
-
-    def close(self) -> None:
-        """Close the underlying serial interface and release all resources"""
-        self._serial.close()
 
     def get_mac_address(self) -> tuple[int, ...]:
         """Retrieve the Bluetooth MAC address of the device

--- a/test/test_serial_base.py
+++ b/test/test_serial_base.py
@@ -115,6 +115,11 @@ class SerialBaseTest(TestCase):
 
         return mock, sot
 
+    def test_property(self):
+        mock, sot = self.create_sot()
+
+        assert sot.raw_serial is mock
+
     def test_flush_input_buf(self):
         mock, sot = self.create_sot()
 
@@ -197,12 +202,6 @@ class SerialBaseTest(TestCase):
 
         r = sot.read_packed("<H")
         self.assertEqual(r, 0x4030)
-
-    def test_close(self):
-        mock, sot = self.create_sot()
-
-        sot.close()
-        self.assertTrue(mock.test_closed)
 
     def test_cancel_read(self):
         mock, sot = self.create_sot()

--- a/test/uart/test_dock_api.py
+++ b/test/uart/test_dock_api.py
@@ -34,15 +34,6 @@ class TestDockAPI:
     def mock(self, sot_and_mock: tuple[ShimmerDock, MockSerial]) -> MockSerial:
         return sot_and_mock[1]
 
-    def test_context_manager(self, sot: ShimmerDock, mock: MockSerial):
-
-        assert not mock.test_closed
-
-        with sot:
-            pass
-
-        assert mock.test_closed
-
     def test_hw_ver_detection(self):
         mock = MockSerial()
 


### PR DESCRIPTION
The close methods in the wrapper Serial classes have been removed. Furthermore, Dock and Bluetooth API won't close the underlying Serial class anymore when they themselves are closed. They didn't create the resource, so it doesn't make sense for them to close it.

Furthermore, the context manager was removed from the Dock API. Since the Dock API class does not hold any resources that it itself created there is no need for the context manager.

The serial instance should always be created within a with context, the same goes for the Bluetooth API. That way, they are always closed correctly and the with context then also handles closing of the serial interface at the right time. The examples were adjusted to reflect this.